### PR TITLE
Differentiate between Background and Font colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ no more :)
 Slides can be defined this way using the slidy's language:
 
 ```text
-:ge :cl 20 40 40 250 :fc 250 250 250 180
+:ge :bc 20 40 40 250 :fc 250 250 250 180
 
 :sl
-:tb :sz 20
+:tb :sz 20 :fc 250 0 0 180
 This is title 1
 :tb :ps 0.1 0.3 :sz 16
 A line \
@@ -26,33 +26,16 @@ Another line \
 And the last one
 
 :sl
-:tb :sz 20
+:tb :sz 20 :fc 250 250 0 180
 And title 2
 :tb :ps 0.1 0.3 :sz 16
 Some other content
 ```
 
-This is usually enough to get some text on screen. A more complicated example
-is shown in `resources/simple_slide.txt`:
-
-```text
-:ge :cl 50 100 200 100
-
-:sl
-:fg star.jpg
-:tb :ps 0.1 0.2 :cl 155 250 255 255 :sz 20
-We can load images.
+This will give you 2 slides with red title and some content.
 
 
-:sl
-:tb :cl 255 150 255 255 :sz 20
-The next slide is imported using the \
-`im` tag. Note that the `generic` \
-section applies to that one as well.
-
-
-:im ./to_import.txt
-```
+A more complicated example is shown in `resources/simple_slide.txt`.
 
 Each usable token is prefixed with a : (column). In this example, we see the
 use of
@@ -60,8 +43,8 @@ use of
   color, and such;
 - :sl, which is the "new slide" identifier;
 - :tb and :fg, which are respectively the "text" and "picture" tokens;
-- :cl (color), :sz(size), :ps(position), that has to be used to put the
-  position of the text inside the slide.
+- :bc, :fc (background and font colors), :sz(size), :ps(position), that has to be used to put
+  the position of the text inside the slide.
   
 These are not all the available tokens; better to take a look at the code to
 see the complete list, in case.
@@ -70,7 +53,10 @@ see the complete list, in case.
 The (0, 0) coordinate is the top-left corner, and (1, 1) is the bottom
 right.
 
-# Goal and non-goals
+### Colors
+Colors are in RGB+Alpha format.
+
+# Goals and non-goals
 `Slidy`'s does _not_ want to be a replacement for PowerPoint (or Impress, or
 whatever): it won't handle all that complexity.
 It can be however (and it is in my case) a much simpler tool for showing simple

--- a/resources/simple_slide.txt
+++ b/resources/simple_slide.txt
@@ -1,13 +1,13 @@
-:ge :cl 50 100 200 100
+:ge :bc 50 100 200 100
 
 :sl
 :fg star.jpg
-:tb :ps 0.1 0.1 :cl 155 250 255 255 :sz 20
+:tb :ps 0.1 0.1 :fc 155 250 255 255 :sz 20
 We can load images.
 
 
 :sl
-:tb :cl 255 150 255 255 :sz 20
+:tb :fc 255 150 255 255 :sz 20
 The next slide is imported using the \
 `im` tag. Note that the `generic` \
 section applies to that one as well.

--- a/resources/to_import.txt
+++ b/resources/to_import.txt
@@ -1,4 +1,4 @@
 :sl
-:tb :ps 0.1 0.2 :cl 255 0 0 255
+:tb :ps 0.1 0.2 :fc 255 0 0 255
 Imported from ./to_import.txt
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -251,10 +251,10 @@ fn main() {
         timer_win.generic_win.canvases_present();
 
         let elapsed = timer.elapsed().unwrap();
-        trace!("max fps: {:?}", sec_as_nanos / elapsed.as_nanos());
+        // trace!("max fps: {:?}", sec_as_nanos / elapsed.as_nanos());
         if elapsed < fixed_fps {
             let sleeptime = fixed_fps - elapsed;
-            trace!("Sleeping for {:?}", sleeptime);
+            // trace!("Sleeping for {:?}", sleeptime);
             // Fix framerate to 10 fps
             sleep(sleeptime);
         } else {


### PR DESCRIPTION
Right now, we have a Color and a FontColor. We want to be able to set a
different font color and background color for all the text/slides, where also
the generic one has an impact.

To do so, we rename Color to BackgroundColor and we make FontColor available in
more sections: this way, it is easier to understand what to set instead of
relying on the code to change the appropriate color when in a "slide" or in a "text"