### PR TITLE
Manage colors via name and via hex code

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,20 +15,21 @@ no more :)
 Slides can be defined this way using the slidy's language:
 
 ```text
-:ge :bc 20 40 40 250 :fc 250 250 250 180
+# Comments are ignored
+:ge :bc green :fc yellow :sz 16
 
 :sl
-:tb :sz 20 :fc 250 0 0 180
+:tb :sz 20 :fc red
 This is title 1
-:tb :ps 0.1 0.3 :sz 16
+:tb :ps 0.1 0.3
 A line
   Another line
     And the last one
 
 :sl
-:tb :sz 20 :fc 250 250 0 180
+:tb :sz 20 :fc blue
 And title 2
-:tb :ps 0.1 0.3 :sz 16
+:tb :ps 0.1 0.3
 Some other content
 ```
 
@@ -54,7 +55,9 @@ The (0, 0) coordinate is the top-left corner, and (1, 1) is the bottom
 right.
 
 ### Colors
-Colors are in RGB+Alpha format.
+Colors are in RGB+Alpha format, and they can be specified as u8 (:cl 200 100
+100 100) hex (:cl #rrggbbaa) or via name (:cl silver)
+(https://encycolorpedia.com/websafe).
 
 # Goals and non-goals
 `Slidy`'s does _not_ want to be a replacement for PowerPoint (or Impress, or

--- a/resources/simple_slide.txt
+++ b/resources/simple_slide.txt
@@ -1,15 +1,15 @@
-:ge :bc 50 100 200 100
+:ge :bc #123456ff :sz 20 :fc green
 
 :sl
 :fg star.jpg
-:tb :ps 0.1 0.1 :fc 155 250 255 255 :sz 20
+:tb :ps 0.1 0.1
 We can load images.
 
 
 :sl
-:tb :fc 255 150 255 255 :sz 20
+:tb :fc fuchsia
 The next slide is imported using the
-  `im` tag. Note that the `generic`
+  \:im tag. Note that the `generic`
     section applies to that one as well.
 
 

--- a/src/parser/utils.rs
+++ b/src/parser/utils.rs
@@ -90,7 +90,7 @@ pub(super) fn manage_textline(
                     slide.sections[last_section].sec_main
                 {
                     if let SectionMain::Text(ref mut text) = sec_main {
-                        text.text.push_str(el);
+                        text.text.push_str(&el.replace("\\:", ":"));
                         text.text.push('\n');
                         Ok(())
                     } else {
@@ -281,6 +281,19 @@ fn extract_f32(t: &Token) -> Result<f32, Box<dyn Error + 'static>> {
     Ok(v)
 }
 
+fn extract_u8(t: &Token) -> Result<u8, Box<dyn Error + 'static>> {
+    let v = extract_f32(t)?;
+    if v.ceil() == v.floor() {
+        // Ceil is the same as floor, so we can assume the value to be an int.
+        let v = v.floor();
+        if (0.0..=255.0).contains(&v) {
+            // We are in the good range!
+            return Ok(v as u8);
+        }
+    }
+    Err(format!("Expect a float, found {:?}", t).into())
+}
+
 pub(super) fn manage_fontcolor(
     lexer: &mut Lexer,
     tokens: &[Token],
@@ -292,16 +305,20 @@ pub(super) fn manage_fontcolor(
                 .into(),
         ),
         General => {
-            lexer.slideshow.font_col = Some(get_color(tokens)?);
-            Ok(4)
+                        let (c, skip) = get_color(tokens)?;
+
+            lexer.slideshow.font_col = Some(c);
+            Ok(skip)
         }
         Text => {
+                        let (c, skip) = get_color(tokens)?;
+
             apply_slide(&mut lexer.internals.slide, |slide| {
                 let last_section = slide.sections.len() - 1;
                 if let Some(ref mut sec_main) = slide.sections[last_section].sec_main {
                     match sec_main {
                         SectionMain::Text(ref mut text) => {
-                            text.color = Some(get_color(tokens)?);
+                            text.color = Some(c);
                         }
                         _ => {
                             return Err("In a text section, but SectionMain is not a text.".into());
@@ -312,22 +329,101 @@ pub(super) fn manage_fontcolor(
                 };
                 Ok(())
             })?;
-            Ok(4)
+            Ok(skip)
         }
     }
 }
 
-fn get_color(tokens: &[Token]) -> Result<Color, Box<dyn Error + 'static>> {
-    // Get 4 numbers
-    if let Some([t1, t2, t3, t4]) = tokens.get(0..4) {
-        let v1 = extract_f32(t1)? as u8; // @todo add error message if not possible
-        let v2 = extract_f32(t2)? as u8;
-        let v3 = extract_f32(t3)? as u8;
-        let v4 = extract_f32(t4)? as u8;
-        Ok((v1, v2, v3, v4).into())
-    } else {
-        Err("BackgroundColor must have 4 tokens after it".into())
+/// Color's names are taken from https://encycolorpedia.com/websafe
+fn match_string_color(
+    color_str: &str,
+) -> Result<Color, Box<dyn Error + 'static>> {
+    // Try to match the exa values
+    if let Some(color_str) = color_str.strip_prefix('#') {
+        // Hex mode
+        for c in color_str.chars() {
+            if !(('0'..='9').contains(&c)
+                || ('a'..='f').contains(&c)
+                || ('A'..='F').contains(&c))
+            {
+                return Err("Only exadecimal characters are allowed.".into());
+            }
+        }
+        if color_str.len() == 8 {
+            let red = u8::from_str_radix(&color_str[0..2], 16)
+                .expect("This cannot fail");
+            let green = u8::from_str_radix(&color_str[2..4], 16)
+                .expect("This cannot fail");
+            let blue = u8::from_str_radix(&color_str[4..6], 16)
+                .expect("This cannot fail");
+            let alpha = u8::from_str_radix(&color_str[6..8], 16)
+                .expect("This cannot fail");
+            return Ok((red, green, blue, alpha).into());
+        } else {
+            return Err("Exa format must be 0xrrggbbaa".into());
+        }
     }
+    // Try to match the string names
+    match color_str.to_lowercase().as_str() {
+        "acqua" => return Ok((0x00, 0xff, 0xff, 0xff).into()),
+        "black" => return Ok((0x00, 0x00, 0x00, 0xff).into()),
+        "blue" => return Ok((0x00, 0x00, 0xff, 0xff).into()),
+        "fuchsia" => return Ok((0xff, 0x00, 0xff, 0xff).into()),
+        "gray" => return Ok((0x80, 0x80, 0x80, 0xff).into()),
+        "green" => return Ok((0x00, 0x80, 0x00, 0xff).into()),
+        "lime" => return Ok((0x00, 0xff, 0x00, 0xff).into()),
+        "maroon" => return Ok((0x80, 0x00, 0x00, 0xff).into()),
+        "navy" => return Ok((0x00, 0x00, 0x80, 0xff).into()),
+        "olive" => return Ok((0x80, 0x80, 0x00, 0xff).into()),
+        "purple" => return Ok((0x80, 0x00, 0x80, 0xff).into()),
+        "red" => return Ok((0xff, 0x00, 0x00, 0xff).into()),
+        "silver" => return Ok((0xc0, 0xc0, 0xc0, 0xff).into()),
+        "teal" => return Ok((0x00, 0x80, 0x80, 0xff).into()),
+        "white" => return Ok((0xff, 0xff, 0xff, 0xff).into()),
+        "yellow" => return Ok((0xff, 0xff, 0x00, 0xff).into()),
+        _ => {}
+    }
+    Err(format!("Unable to parse {} into a known color.", color_str).into())
+}
+
+fn get_color(
+    tokens: &[Token],
+) -> Result<(Color, usize), Box<dyn Error + 'static>> {
+    // Get 4 numbers
+    let mut res = None;
+    let mut err_msg = String::with_capacity(1024);
+    trace!("get_color: check if there are 4 tokens.");
+    if let Some([t1, t2, t3, t4]) = tokens.get(0..4) {
+        let v1 = extract_u8(t1);
+        let v2 = extract_u8(t2);
+        let v3 = extract_u8(t3);
+        let v4 = extract_u8(t4);
+        if let (Ok(v1), Ok(v2), Ok(v3), Ok(v4)) = (v1, v2, v3, v4) {
+            res = Some((v1, v2, v3, v4));
+        } else {
+            err_msg.push_str(&format!("found 4 invalid tokens, but some are invalid: {:?} {:?} {:?} {:?}", t1, t2, t3, t4));
+        }
+    }
+    if let Some(res) = res {
+        return Ok((res.into(), 4));
+    }
+    trace!("get_color: check if a single token works.");
+    // Res was not ok, try to take a single string.
+    if let Some(t) = tokens.get(0) {
+        if let Structure::String(el) = t.symbol {
+            match match_string_color(el) {
+                Ok(c) => return Ok((c, 1)),
+                Err(e) => err_msg.push_str(&format!(
+                    "unable to get the color out of a string: {}",
+                    e
+                )),
+            }
+        }
+        err_msg.push_str("token is not a string, unable to get the color out");
+    } else {
+        err_msg.push_str("not enough tokens to take the color out");
+    }
+    Err(err_msg.into())
 }
 
 pub(super) fn manage_bg_color(
@@ -341,16 +437,17 @@ pub(super) fn manage_bg_color(
                 .into(),
         ),
         General => {
-            lexer.slideshow.bg_col = Some(get_color(tokens)?);
-            Ok(4)
+            let (c, skip) = get_color(tokens)?;
+            lexer.slideshow.bg_col = Some(c);
+            Ok(skip)
         }
         Slide => {
-
+            let (c, skip) = get_color(tokens)?;
             apply_slide(&mut lexer.internals.slide, |slide| {
-                slide.bg_color = Some(get_color(tokens)?);
+                slide.bg_color = Some(c);
                 Ok(())
             })?;
-            Ok(4)
+            Ok(skip)
         }}
 }
 
@@ -391,5 +488,68 @@ pub(super) fn manage_rotation(
             })?;
             Ok(1)
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::parser::tokenizer::tokenizer;
+
+    use super::*;
+
+    #[test]
+    fn get_color_ok() {
+        let tokens = tokenizer(":cl 0 23 2 42");
+        let c = get_color(&tokens[1..]);
+        assert!(c.is_ok(), "{:#?}", c);
+        let c = c.unwrap().0;
+        assert_eq!(c.r, 0, "{:?}", c);
+        assert_eq!(c.g, 23, "{:?}", c);
+        assert_eq!(c.b, 2, "{:?}", c);
+        assert_eq!(c.a, 42, "{:?}", c);
+    }
+
+    #[test]
+    fn get_color_ok_2() {
+        let tokens = tokenizer(":cl #0305a0c1");
+        let c = get_color(&tokens[1..]);
+        assert!(c.is_ok(), "{:?}", c);
+        let c = c.unwrap().0;
+        assert_eq!(c.r, 3, "{:?}", c);
+        assert_eq!(c.g, 5, "{:?}", c);
+        assert_eq!(c.b, 160, "{:?}", c);
+        assert_eq!(c.a, 193, "{:?}", c);
+    }
+
+    #[test]
+    fn get_color_ok_3() {
+        let tokens = tokenizer(":cl silver");
+        let c = get_color(&tokens[1..]);
+        assert!(c.is_ok(), "{:?}", c);
+        let c = c.unwrap().0;
+        assert_eq!(c.r, 192, "{:?}", c);
+        assert_eq!(c.g, 192, "{:?}", c);
+        assert_eq!(c.b, 192, "{:?}", c);
+        assert_eq!(c.a, 255, "{:?}", c);
+    }
+
+    #[test]
+    fn get_color_ko() {
+        let tokens = tokenizer(":cl pinka");
+        let c = get_color(&tokens[1..]);
+        assert!(c.is_err(), "{:?}", c);
+    }
+
+    #[test]
+    fn get_color_ko2() {
+        let tokens = tokenizer(":cl 300 200 100 100");
+        let c = get_color(&tokens[1..]);
+        assert!(c.is_err(), "{:?}", c);
+    }
+    #[test]
+    fn get_color_ko3() {
+        let tokens = tokenizer(":cl #q2222222");
+        let c = get_color(&tokens[1..]);
+        assert!(c.is_err(), "{:?}", c);
     }
 }


### PR DESCRIPTION
This patch allows to use colors using a name or an hex instead of the u8 value